### PR TITLE
Add configurable redisKeyPrefix for multi-site Redis isolation

### DIFF
--- a/src/adapters/RedisSearchAdapter.php
+++ b/src/adapters/RedisSearchAdapter.php
@@ -39,6 +39,10 @@ class RedisSearchAdapter extends BaseSearchAdapter
         $redisHost = App::parseEnv('$BRAMBLE_SEARCH_REDIS_HOST') ?: $settings->redisHost;
         $redisPort = (int)(App::parseEnv('$BRAMBLE_SEARCH_REDIS_PORT') ?: $settings->redisPort);
         $redisPassword = App::parseEnv('$BRAMBLE_SEARCH_REDIS_PASSWORD') ?: $settings->redisPassword;
+        $redisKeyPrefix = App::parseEnv('$BRAMBLE_SEARCH_REDIS_KEY_PREFIX') ?: $settings->redisKeyPrefix;
+        if ($redisKeyPrefix !== '') {
+            $this->prefix = $redisKeyPrefix;
+        }
 
         $this->redis = new Redis();
         $this->redis->connect($redisHost, $redisPort);

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -37,6 +37,11 @@ class Settings extends Model
     public string|null $redisPassword = null;
 
     /**
+     * Redis key prefix (allows multiple Bramble sites to share the same Redis instance/DB).
+     */
+    public string $redisKeyPrefix = 'bramble_search:';
+
+    /**
      * MongoDB connection URI
      */
     public string $mongoDbUri = 'mongodb://localhost:27017';

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -103,6 +103,22 @@
         value: settings.redisPassword,
         errors: settings.getErrors('redisPassword'),
     }) }}
+
+    {% set envKeyPrefix = parseEnv('$BRAMBLE_SEARCH_REDIS_KEY_PREFIX') %}
+    {% set hasEnvKeyPrefix = envKeyPrefix is not empty and envKeyPrefix != '$BRAMBLE_SEARCH_REDIS_KEY_PREFIX' %}
+    {{ forms.textField({
+        label: "Redis Key Prefix"|t('bramble-search'),
+        instructions: "Prefix used for all Redis keys. Allows multiple Bramble-enabled sites to share the same Redis instance/database without collisions."|t('bramble-search'),
+        tip: "Default 'bramble_search:'. Change it (e.g. 'bramble_search_mysite:') if you share Redis with another site. Can be overridden with the BRAMBLE_SEARCH_REDIS_KEY_PREFIX environment variable."|t('bramble-search'),
+        warning: hasEnvKeyPrefix
+            ? ("Currently overridden by the BRAMBLE_SEARCH_REDIS_KEY_PREFIX environment variable: " ~ envKeyPrefix)|t('bramble-search')
+            : null,
+        id: 'redisKeyPrefix',
+        name: 'redisKeyPrefix',
+        placeholder: 'bramble_search:',
+        value: settings.redisKeyPrefix,
+        errors: settings.getErrors('redisKeyPrefix'),
+    }) }}
 </div>
 
 <div id="storage-mongodb" class="{% if settings.storageDriver != 'mongodb' %}hidden{% endif %}">


### PR DESCRIPTION
## Problem

  Currently the Redis adapter hardcodes the key prefix to `bramble_search:` (inherited from
  `BaseSearchAdapter`). When two Craft sites both run Bramble Search against the same Redis instance/DB,
  their indexes overwrite each other:
  
  - `meta`, `term:*`, `ngram:*`, `term_ngrams:*` are **not** namespaced by siteId → fully shared.
  - `doc:{siteId}:*` and `title:{siteId}:*` are namespaced by siteId, but the primary site in each Craft is
  usually id `1`, so they still collide.

  Typical symptoms when this hits:

  - Searching on site A returns documents from site B.
  - BM25 scoring is computed over a mixed corpus.
  - Re-indexing one site overwrites the shared `meta` key and corrupts the other's stats.

  ## What this PR does
  
  Adds an optional `redisKeyPrefix` setting:

  - Defaults to `bramble_search:` (backward-compatible — existing installs are unaffected).
  - Overridable via the `BRAMBLE_SEARCH_REDIS_KEY_PREFIX` environment variable (same pattern as the existing
  `BRAMBLE_SEARCH_REDIS_HOST` / `_PORT` / `_PASSWORD`).
  - Exposed as a CP text field with an active `warning` indicator that displays the resolved env value when
  overridden, so users don't get surprised by a silently-ignored CP value.

  Each site can then pick its own prefix (e.g. `bramble_search_qr:`, `bramble_search_sempe:`) and run on the
  same Redis without collisions.

  ## Files touched

  - `src/models/Settings.php` — new `$redisKeyPrefix` property.
  - `src/adapters/RedisSearchAdapter.php` — reads the env var / setting in `init()` and overrides
  `$this->prefix`.
  - `src/templates/_settings.twig` — new CP field with env-aware `warning`.

  ## Resolution order at runtime

  1. `BRAMBLE_SEARCH_REDIS_KEY_PREFIX` env var (wins if set).
  2. CP setting `redisKeyPrefix` (used if no env var).
  3. Default `bramble_search:` (if neither).